### PR TITLE
Massive changes (see comments)

### DIFF
--- a/contracts/GalionTokenSale.sol
+++ b/contracts/GalionTokenSale.sol
@@ -20,12 +20,14 @@ contract GalionTokenSale is PhaseWhitelist {
     TokenTimelock public teamLockAddress4;
     TokenTimelock public teamLockAddress5;
 
+    // max supply is 320 million with 18 decimals
+    uint256 public constant MAXSUPPLY = 320 * (10 ** 6) * (10 ** 18);
     // soft cap is 26% of total supply
-    uint256 public constant SOFTCAP = 83 * (10 ** 6) * (10 ** 18);
+    uint256 public constant SOFTCAP = MAXSUPPLY.div(100).mul(26);
     // presale cap is 50% of total supply
-    uint256 public constant PRESALECAP = 160 * (10 ** 6) * (10 ** 18);
+    uint256 public constant PRESALECAP = MAXSUPPLY.div(100).mul(50);
     // hard cap is 60% of total supply
-    uint256 public constant HARDCAP = 192 * (10 ** 6) * (10 ** 18);
+    uint256 public constant HARDCAP = MAXSUPPLY.div(100).mul(60);
 
     // buy price = how much token can 1 ETH buy
     uint256 public baseBuyPrice = 0;

--- a/contracts/GalionTokenSale.sol
+++ b/contracts/GalionTokenSale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^ 0.4 .24;
 
 import "./OpenZeppelin/SafeMath.sol";
 import "./OpenZeppelin/TokenTimelock.sol";
@@ -10,58 +10,43 @@ import "./PhaseWhitelist.sol";
 // developed by contact@it.galion.io
 // ----------------------------------------------------------------------------
 contract GalionTokenSale is PhaseWhitelist {
-    using SafeMath for uint256;
+    using SafeMath
+    for uint256;
 
     GalionToken public token;
     address public constant COMPANY_ADDRESS = address(0x849F14948588d2bDe7a3ff68DE9269b2160483C1);
+    address public constant ADVISORY_ADDRESS = address(0x5a2a667f7A416D4660a7464c6C555F0Ecb328e2a);
     TokenTimelock public teamLockAddress1;
     TokenTimelock public teamLockAddress2;
     TokenTimelock public teamLockAddress3;
     TokenTimelock public teamLockAddress4;
     TokenTimelock public teamLockAddress5;
 
-    // soft cap is 26% of total supply
-    uint256 public constant SOFTCAP = 83 * (10 ** 6) * (10 ** 18);
-    // presale cap is 50% of total supply
-    uint256 public constant PRESALECAP = 160 * (10 ** 6) * (10 ** 18);
-    // hard cap is 60% of total supply
-    uint256 public constant HARDCAP = 192 * (10 ** 6) * (10 ** 18);
+    // amount of dollar raised, costant, used to define softcap, presalecap and hardcap
+    uint256 public constant DOLLARTARGET = 9500000;
+
+    // the following variables are used to define the different caps of the sale
+    // they are set in the "setEthPrice" function
+    uint256 public weiSoftCap = 0;
+    uint256 public weiPresaleCap = 0;
+    uint256 public weiHardCap = 0;
 
     // buy price = how much token can 1 ETH buy
     uint256 public baseBuyPrice = 0;
 
-    // presale bonus (in multiplier percent). E.g. 130 = 130% multiplier = *1.3 = 30% bonus.
-    uint256 public preSaleBonus = 130;
+    // presale bonus (in percent)
+    uint256 public constant PRESALEBONUS = 30;
 
     // amount of raised money in wei
     uint256 public weiRaised = 0;
-    uint256 public tokenSold = 0;
-    uint256 public weiSoftCap = 0;
 
     constructor() public {
         // Token contract creation
         token = new GalionToken();
-        uint256 tokens = 10 ** uint256(token.decimals()); // alias for token's decimals
-
-        // Mint company tokens
-        token.mint(COMPANY_ADDRESS, 96000000 * tokens);
-
-        // Mint & lock team tokens
-        uint256 releaseTime = block.timestamp + 52 weeks;
-        teamLockAddress1 = new TokenTimelock(token, address(0x4933916d10aB8225a33F3a8bae7CF1A8AA316068), releaseTime);
-        teamLockAddress2 = new TokenTimelock(token, address(0x531A551dE22317857b10d9FaB69674E56130679e), releaseTime);
-        teamLockAddress3 = new TokenTimelock(token, address(0xDe6fdA07c2f16dE22654B707c80d25705f6410a5), releaseTime);
-        teamLockAddress4 = new TokenTimelock(token, address(0x13E45dFF393716f3169E34Dd9039468975b808C6), releaseTime);
-        teamLockAddress5 = new TokenTimelock(token, address(0xFcCB4C7D53745f03DF19039f3B37083D0E4ff47B), releaseTime);
-        token.mint(teamLockAddress1, 6400000 * tokens);
-        token.mint(teamLockAddress2, 6400000 * tokens);
-        token.mint(teamLockAddress3, 6400000 * tokens);
-        token.mint(teamLockAddress4, 6400000 * tokens);
-        token.mint(teamLockAddress5, 6400000 * tokens);
     }
 
     // Default function called when someone is sending ETH : redirects to the ICO buy function.
-    function() public payable {
+    function () public payable {
         buyGLN();
     }
 
@@ -76,12 +61,12 @@ contract GalionTokenSale is PhaseWhitelist {
         // Compute buy price (with bonus applied if presale is in progress)
         uint256 buyPrice = baseBuyPrice;
         // set the correct cap for the phase
-        uint256 phaseCap = HARDCAP;
+        uint256 phaseCap = weiHardCap;
 
+        // if presale, check that the contribution is at least 1 ETH and set the phaseCap to the presale Cap
         if (phase == 0) {
-            buyPrice = baseBuyPrice.mul(preSaleBonus).div(100);
             require(msg.value >= 10 ** 18);
-            phaseCap = PRESALECAP;
+            phaseCap = weiPresaleCap;
         }
 
         // individual cap check if current phase is safe mainsale
@@ -94,31 +79,45 @@ contract GalionTokenSale is PhaseWhitelist {
             }
         }
 
-        // Amount of tokens bought
-        uint256 buyAmount = msg.value.mul(buyPrice);
-        uint256 futureTokenSold = tokenSold + buyAmount;
+        uint256 futureWeiRaised = weiRaised.add(msg.value);
 
         // Check for hardcap
-        require(futureTokenSold <= phaseCap);
+        require(futureWeiRaised <= phaseCap);
+
+        // here, all the test have been made to check if the user can buy tokens
 
         // Mint token & assign to contributor
+        // Amount of tokens bought
+        uint256 buyAmount = msg.value.mul(buyPrice);
         contributed[msg.sender] = contributed[msg.sender].add(msg.value);
-        tokenSold = futureTokenSold;
-        weiRaised = weiRaised.add(msg.value);
+        weiRaised = futureWeiRaised;
         token.mint(msg.sender, buyAmount);
 
+        // if in presale, also give PRESALEBONUS token in a token time lock contract
+        if (phase == 0) {
+            address tokenTimeLockAddress = timelock[msg.sender];
+            // if the contributor does not have a contract yet, create it
+            if (tokenTimeLockAddress == address(0)) {
+                tokenTimeLockAddress = new TokenTimelock(token, address(msg.sender), presaleReleaseDate);
+                timelock[msg.sender] = tokenTimeLockAddress;
+            }
+
+            // here, the contract time lock address is set (already exist or new contract has been deployed)
+            // mint the bonus token to the contract
+            token.mint(tokenTimeLockAddress, buyAmount.mul(PRESALEBONUS).div(100));
+        }
+
         // end the token generation event if the total token sold is the hard cap
-        if (tokenSold == HARDCAP) {
+        if (weiRaised == weiHardCap) {
             phase = 4;
         }
     }
 
-    // Set buy price (tokens per ETH, without bonus).
-    // because both have 18 decimal, newBuyPrice is "how much token can be bought with 1 eth"
-    // can and must be set once during the presale or nobody can contribute
-    // can be reset during the pause phase (to adjust the price)
-    // will recalc the soft cap wei
-    function setBuyPrice(uint256 newBuyPrice) public onlyOwner {
+    // set the price of 1 ETH in $, exemple 1 ETH = $ 515
+    // can (and must) be set once during the presale or nobody can contribute
+    // can be reset during the pause phase (to adjust the price if the price has dropped or mooned)
+    // using the constant "DOLLARTARGET", the calculation of the weiSoftCap, weiPresaleCap and weiHardcap and the buyPrice is done here
+    function setEthPrice(uint256 ethPriceInDollar) public onlyOwner {
         // the base price can only be changed before the main sale
         require(phase < 2);
         // can be set only once during presale
@@ -126,12 +125,19 @@ contract GalionTokenSale is PhaseWhitelist {
             require(baseBuyPrice == 0);
         }
 
-        require(newBuyPrice > 0);
+        require(ethPriceInDollar > 0);
 
-        baseBuyPrice = newBuyPrice;
+        // the tokenBuyPrice is set using the value 0.05$ / token
+        baseBuyPrice = ethPriceInDollar.mul(20);
 
-        // calculate the weiSoftCap
-        weiSoftCap = HARDCAP.div(baseBuyPrice).mul(26).div(100);
+        // the sale hardcap in wei is how much wei is needed to reach 9.5M$
+        weiHardCap = DOLLARTARGET.div(ethPriceInDollar).mul(10 ** 18);
+
+        // the soft cap is 26% of the hardcap
+        weiSoftCap = weiHardCap.mul(26).div(100);
+
+        // the presale cap is 80% of the sale hardcap
+        weiPresaleCap = weiHardCap.mul(80).div(100);
     }
 
     // Withdraw all ETH stored on the contract, by sending them to the company address
@@ -148,8 +154,8 @@ contract GalionTokenSale is PhaseWhitelist {
     function refund(address contributor) public {
         // cannot refund if the soft cap in wei has been reached
         require(weiRaised < weiSoftCap);
-        // allow to get a refund if the phase is TGE over or if the main sale if over (timestamp)
-        require(phase >= 4 || (phase == 3 && block.timestamp > mainsaleEnd));
+        // allow to get a refund if the phase is TGE over or if the main sale if over (over the timestamp)
+        require(phase >= 4 || ((phase == 2 || phase == 3) && block.timestamp > mainsaleEnd));
 
         uint256 contributedWei = contributed[contributor];
         require(contributedWei > 0);
@@ -165,6 +171,29 @@ contract GalionTokenSale is PhaseWhitelist {
         require(phase >= 4);
         // cannot activate the token if the soft cap is not reached
         require(weiRaised >= weiSoftCap);
+
+        // the total minted during the sale must represent 60% of the supply total
+        uint256 realTotalSupply = token.totalSupply().mul(100).div(60);
+        // Mint company tokens (20% of the )
+        token.mint(COMPANY_ADDRESS, realTotalSupply.mul(20).div(100));
+        token.mint(ADVISORY_ADDRESS, realTotalSupply.mul(10).div(100));
+
+        // Mint & lock team tokens
+        uint256 releaseTime = block.timestamp + 52 weeks;
+        teamLockAddress1 = new TokenTimelock(token, address(0x4933916d10aB8225a33F3a8bae7CF1A8AA316068), releaseTime);
+        teamLockAddress2 = new TokenTimelock(token, address(0x531A551dE22317857b10d9FaB69674E56130679e), releaseTime);
+        teamLockAddress3 = new TokenTimelock(token, address(0xDe6fdA07c2f16dE22654B707c80d25705f6410a5), releaseTime);
+        teamLockAddress4 = new TokenTimelock(token, address(0x13E45dFF393716f3169E34Dd9039468975b808C6), releaseTime);
+        teamLockAddress5 = new TokenTimelock(token, address(0xFcCB4C7D53745f03DF19039f3B37083D0E4ff47B), releaseTime);
+        token.mint(teamLockAddress1, realTotalSupply.mul(2).div(100));
+        token.mint(teamLockAddress2, realTotalSupply.mul(2).div(100));
+        token.mint(teamLockAddress3, realTotalSupply.mul(2).div(100));
+        token.mint(teamLockAddress4, realTotalSupply.mul(2).div(100));
+        token.mint(teamLockAddress5, realTotalSupply.mul(2).div(100));
+
+        // now the total supply of the token is composed of 60% of tokens sold during the sale
+        // and 40% of token given to the company / founders
+        // we can now activate the token
 
         token.activate();
         token.transferOwnership(owner);

--- a/contracts/GalionTokenSale.sol
+++ b/contracts/GalionTokenSale.sol
@@ -1,4 +1,4 @@
-pragma solidity ^ 0.4 .24;
+pragma solidity ^0.4.24;
 
 import "./OpenZeppelin/SafeMath.sol";
 import "./OpenZeppelin/TokenTimelock.sol";

--- a/contracts/GalionTokenSale.sol
+++ b/contracts/GalionTokenSale.sol
@@ -98,7 +98,7 @@ contract GalionTokenSale is PhaseWhitelist {
             // if the contributor does not have a contract yet, create it
             if (tokenTimeLockAddress == address(0)) {
                 // create the timelock contract with a release date in 3 months
-                tokenTimeLockAddress = new TokenTimelock(token, address(msg.sender), block.timestamp + 14 weeks);
+                tokenTimeLockAddress = new TokenTimelock(token, address(msg.sender), block.timestamp + 10 weeks);
                 timelock[msg.sender] = tokenTimeLockAddress;
             }
 

--- a/contracts/GalionTokenSale.sol
+++ b/contracts/GalionTokenSale.sol
@@ -98,7 +98,7 @@ contract GalionTokenSale is PhaseWhitelist {
             // if the contributor does not have a contract yet, create it
             if (tokenTimeLockAddress == address(0)) {
                 // create the timelock contract with a release date in 3 months
-                tokenTimeLockAddress = new TokenTimelock(token, address(msg.sender), block.timestamp + 10 weeks);
+                tokenTimeLockAddress = new TokenTimelock(token, address(msg.sender), block.timestamp + 90 days);
                 timelock[msg.sender] = tokenTimeLockAddress;
             }
 

--- a/contracts/GalionTokenSale.sol
+++ b/contracts/GalionTokenSale.sol
@@ -30,8 +30,8 @@ contract GalionTokenSale is PhaseWhitelist {
     // buy price = how much token can 1 ETH buy
     uint256 public baseBuyPrice = 0;
 
-    // presale bonus (in multiplier percent). E.g. 120 = 120% multiplier = *1.2 = 20% bonus.
-    uint256 public preSaleBonus = 120;
+    // presale bonus (in multiplier percent). E.g. 130 = 130% multiplier = *1.3 = 30% bonus.
+    uint256 public preSaleBonus = 130;
 
     // amount of raised money in wei
     uint256 public weiRaised = 0;
@@ -110,12 +110,6 @@ contract GalionTokenSale is PhaseWhitelist {
         if (tokenSold == HARDCAP) {
             phase = 4;
         }
-    }
-
-    // Set presale bonus
-    function setPreSaleBonus(uint256 newBonus) public onlyOwner {
-        require(newBonus >= 100);
-        preSaleBonus = newBonus;
     }
 
     // Set buy price (tokens per ETH, without bonus).

--- a/contracts/GalionTokenSale.sol
+++ b/contracts/GalionTokenSale.sol
@@ -10,8 +10,7 @@ import "./PhaseWhitelist.sol";
 // developed by contact@it.galion.io
 // ----------------------------------------------------------------------------
 contract GalionTokenSale is PhaseWhitelist {
-    using SafeMath
-    for uint256;
+    using SafeMath for uint256;
 
     GalionToken public token;
     address public constant COMPANY_ADDRESS = address(0x849F14948588d2bDe7a3ff68DE9269b2160483C1);

--- a/contracts/GalionTokenSale.sol
+++ b/contracts/GalionTokenSale.sol
@@ -43,6 +43,9 @@ contract GalionTokenSale is PhaseWhitelist {
     constructor() public {
         // Token contract creation
         token = new GalionToken();
+
+        // set the presale release date in 5 months (should be around 3 month after the end of the sale)
+        presaleReleaseDate = block.timestamp + 140 days;
     }
 
     // Default function called when someone is sending ETH : redirects to the ICO buy function.

--- a/contracts/GalionTokenSale.sol
+++ b/contracts/GalionTokenSale.sol
@@ -42,9 +42,6 @@ contract GalionTokenSale is PhaseWhitelist {
     constructor() public {
         // Token contract creation
         token = new GalionToken();
-
-        // set the presale release date in 5 months (should be around 3 month after the end of the sale)
-        presaleReleaseDate = block.timestamp + 140 days;
     }
 
     // Default function called when someone is sending ETH : redirects to the ICO buy function.
@@ -100,11 +97,12 @@ contract GalionTokenSale is PhaseWhitelist {
             address tokenTimeLockAddress = timelock[msg.sender];
             // if the contributor does not have a contract yet, create it
             if (tokenTimeLockAddress == address(0)) {
-                tokenTimeLockAddress = new TokenTimelock(token, address(msg.sender), presaleReleaseDate);
+                // create the timelock contract with a release date in 3 months
+                tokenTimeLockAddress = new TokenTimelock(token, address(msg.sender), block.timestamp + 14 weeks);
                 timelock[msg.sender] = tokenTimeLockAddress;
             }
 
-            // here, the contract time lock address is set (already exist or new contract has been deployed)
+            // here, the contract time lock address is set (already exists or new contract has been deployed)
             // mint the bonus token to the contract
             token.mint(tokenTimeLockAddress, buyAmount.mul(PRESALEBONUS).div(100));
         }

--- a/contracts/GalionTokenSale.sol
+++ b/contracts/GalionTokenSale.sol
@@ -23,11 +23,11 @@ contract GalionTokenSale is PhaseWhitelist {
     // max supply is 320 million with 18 decimals
     uint256 public constant MAXSUPPLY = 320 * (10 ** 6) * (10 ** 18);
     // soft cap is 26% of total supply
-    uint256 public constant SOFTCAP = MAXSUPPLY.div(100).mul(26);
+    uint256 public SOFTCAP = MAXSUPPLY.div(100).mul(26);
     // presale cap is 50% of total supply
-    uint256 public constant PRESALECAP = MAXSUPPLY.div(100).mul(50);
+    uint256 public PRESALECAP = MAXSUPPLY.div(100).mul(50);
     // hard cap is 60% of total supply
-    uint256 public constant HARDCAP = MAXSUPPLY.div(100).mul(60);
+    uint256 public HARDCAP = MAXSUPPLY.div(100).mul(60);
 
     // buy price = how much token can 1 ETH buy
     uint256 public baseBuyPrice = 0;

--- a/contracts/PhaseWhitelist.sol
+++ b/contracts/PhaseWhitelist.sol
@@ -48,7 +48,7 @@ contract PhaseWhitelist is Ownable {
             // set the end of safe mainsale timestamp
             safeMainsaleEnd = block.timestamp + 12 hours;
             // set the end of the main sale timestamp
-            mainsaleEnd = block.timestamp + 2 weeks;
+            mainsaleEnd = block.timestamp + 3 weeks;
         }
         
         // can only change phase from 2 (safe main sale) to 3 (main sale) if the end timestamp of the safe main sale is reached

--- a/contracts/PhaseWhitelist.sol
+++ b/contracts/PhaseWhitelist.sol
@@ -20,6 +20,11 @@ contract PhaseWhitelist is Ownable {
     // individual wei cap during safe sale, must be set before calling the"setSaleStartBlock" and used to allow
     // every whitelisted user to have a share
     uint256 public individualWeiCap = 0;
+    
+    // presale bonus token release date = 2019/01/01
+    uint public presaleReleaseDate = 1546300800;
+    // mapping of timelock contracts used in the presale to lock bonus token until 2019/01/01
+    mapping(address => address) timelock;
 
     // Indicator of the crowdsale phase (0 = presale, 1 = pause, 2 = safe mainsale, 3 = mainsale, 4 = TGE over)
     uint8 public phase = 0;
@@ -86,6 +91,11 @@ contract PhaseWhitelist is Ownable {
     // Public function to check if an address is in the whitelist
     function checkWhitelisted(address _addr) public view returns (bool) {
         return whitelist[_addr] > 0;
+    }
+
+    // Public function to check the address of the time lock contract for a contributor
+    function getTimelockContractAddress(address _addr) public view returns (address) {
+        return timelock[_addr];
     }
 
     // Add addresses to whitelist (level = presale).

--- a/contracts/PhaseWhitelist.sol
+++ b/contracts/PhaseWhitelist.sol
@@ -21,8 +21,6 @@ contract PhaseWhitelist is Ownable {
     // every whitelisted user to have a share
     uint256 public individualWeiCap = 0;
     
-    // presale bonus token release date = 2019/01/01
-    uint public presaleReleaseDate;
     // mapping of timelock contracts used in the presale to lock bonus token until 2019/01/01
     mapping(address => address) timelock;
 

--- a/contracts/PhaseWhitelist.sol
+++ b/contracts/PhaseWhitelist.sol
@@ -22,7 +22,7 @@ contract PhaseWhitelist is Ownable {
     uint256 public individualWeiCap = 0;
     
     // presale bonus token release date = 2019/01/01
-    uint public presaleReleaseDate = 1546300800;
+    uint public presaleReleaseDate;
     // mapping of timelock contracts used in the presale to lock bonus token until 2019/01/01
     mapping(address => address) timelock;
 

--- a/test/GalionTokenSale.test.js
+++ b/test/GalionTokenSale.test.js
@@ -647,8 +647,7 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             assert.equal(await token.activated(), true);
         });
 
-        // test a activer après le merge dans master
-        it.skip('should not be able to activate token if the soft cap is not reached', async function () {
+        it('should not be able to activate token if the soft cap is not reached', async function () {
             await setContractToTGEOver(false);
 
             try {

--- a/test/GalionTokenSale.test.js
+++ b/test/GalionTokenSale.test.js
@@ -64,7 +64,7 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
         web3.currentProvider.sendAsync({
             jsonrpc: "2.0",
             method: "evm_increaseTime",
-            params: [(3600 * 24 * 14) + 1],
+            params: [(3600 * 24 * 21) + 1],
             id: 12345
         }, function (err, result) {});
 
@@ -565,7 +565,7 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             web3.currentProvider.sendAsync({
                 jsonrpc: "2.0",
                 method: "evm_increaseTime",
-                params: [(3600 * 24 * 14) + 1],
+                params: [(3600 * 24 * 21) + 1],
                 id: 12345
             }, function (err, result) {});
 
@@ -592,7 +592,7 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             web3.currentProvider.sendAsync({
                 jsonrpc: "2.0",
                 method: "evm_increaseTime",
-                params: [(3600 * 24 * 14) + 1],
+                params: [(3600 * 24 * 21) + 1],
                 id: 12345
             }, function (err, result) {
 
@@ -661,7 +661,7 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             web3.currentProvider.sendAsync({
                 jsonrpc: "2.0",
                 method: "evm_increaseTime",
-                params: [(3600 * 24 * 14) + 1],
+                params: [(3600 * 24 * 21) + 1],
                 id: 12345
             }, function (err, result) {});
 

--- a/test/GalionTokenSale.test.js
+++ b/test/GalionTokenSale.test.js
@@ -108,8 +108,6 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             assert.equal(await token.activated(), false);
         });
 
-
-
         it('should deploy with the phase equals to 0', async function () {
             assert.equal(await tokenSaleContract.getCurrentPhase(), 0);
         });
@@ -163,7 +161,7 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             }
         });
 
-        it('should not be able to whitelist an address price if not the owner', async function () {
+        it('should not be able to whitelist an address if not the owner', async function () {
             try {
                 await tokenSaleContract.addToWhitelist([notWhitelisted], {
                     from: contributor
@@ -194,7 +192,7 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             assert.equal(addr, '0x0000000000000000000000000000000000000000');
         });
 
-        it('SHould be able to set the eth price in dollar', async function () {
+        it('Should be able to set the eth price in dollar', async function () {
             await tokenSaleContract.setEthPrice(ETH_PRICE);
             var weiHardCap = await tokenSaleContract.weiHardCap();
             // the hardcap is the amount of wei needed to raise 9 500 000 $
@@ -408,13 +406,12 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
     });
 
     contract('Pause phase', async function () {
-
-        it('should be able to pause the sale', async function () {
+        it('should be able to pause the sale after presale', async function () {
             await tokenSaleContract.setPhase(1);
             assert.equal(await tokenSaleContract.getCurrentPhase(), 1);
         });
 
-        it('should no be able to contribute during the pause', async function () {
+        it('should not be able to contribute during the pause', async function () {
             await setContractToPausePhase();
 
             try {
@@ -474,6 +471,7 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
                 assert(error.toString().includes('revert'), error.toString());
             }
         });
+
         it('should be able to set individual cap & start safe mainsale', async function () {
             await setContractToSafeMainSale();
             assert.equal(await tokenSaleContract.getCurrentPhase(), 2);
@@ -804,7 +802,7 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             assert.equal((await token.balanceOf(notWhitelisted)), 1000 * GLN);
         });
 
-        it('should allow to withdraw ether if the soft cap is reached', async function () {
+        it('should allow to withdraw ether to Galion multisig if the soft cap is reached', async function () {
             // setting true means the soft cap is reached and the whitelistedInPresale contributor has tokens
             await setContractToTGEOver(true);
 
@@ -827,7 +825,6 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
                 assert(error.toString().includes('revert'), error.toString());
             }
         });
-
 
         it('should send 20% of supply to company wallet', async function () {
             await setContractToTGEOver(true);
@@ -865,7 +862,6 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             await tokenSaleContract.activateToken();
 
             // due to rounding issue, will test with greater and lower than
-
             var highBound = 0.02001 * await token.totalSupply();
             var lowBound = 0.01999 * await token.totalSupply();
 

--- a/test/GalionTokenSale.test.js
+++ b/test/GalionTokenSale.test.js
@@ -837,7 +837,7 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             // due to rounding issue, will test with greater and lower than
 
             var highBound = 0.2001 * await token.totalSupply();
-            var lowBound = 0.01999 * await token.totalSupply();
+            var lowBound = 0.1999 * await token.totalSupply();
 
             var tokenNumForCompany = (await token.balanceOf(COMPANY_ADDRESS)).toNumber()
             if (tokenNumForCompany > highBound) {

--- a/test/GalionTokenSale.test.js
+++ b/test/GalionTokenSale.test.js
@@ -210,7 +210,6 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
         it('Should not be able to set the eth price two times', async function () {
             await tokenSaleContract.setEthPrice(ETH_PRICE);
             try {
-
                 await tokenSaleContract.setEthPrice(10);
                 assert.fail();
             } catch (error) {
@@ -363,7 +362,7 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             assert.equal(await token.balanceOf(whitelistedInPresale), weiToContributeToReachPresaleHardCap * buyPrice);
         });
 
-        it('should not allow to contribute after the hardcap is reached in the presale, considering the bonus', async function () {
+        it('should not allow to contribute after the hardcap is reached in the presale', async function () {
             await tokenSaleContract.setEthPrice(ETH_PRICE);
             var weiToContributeToReachPresaleHardCap = 80 * ETH;
             await tokenSaleContract.sendTransaction({
@@ -590,7 +589,7 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
     });
 
     contract('Mainsale', async function () {
-        it('should not be able to start the main sale using the set phase function during the presale', async function () {
+        it('should not be able to start the main sale using the set phase function during the safe mainsale', async function () {
             await setContractToSafeMainSale();
 
             try {
@@ -959,10 +958,8 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
         it('should not allow people to claim refund during the pause', async function () {
             await tokenSaleContract.setEthPrice(ETH_PRICE);
 
-            const contributingEth = 1;
-
             await tokenSaleContract.sendTransaction({
-                value: contributingEth * ETH,
+                value: 1 * ETH,
                 from: whitelistedInPresale
             });
 
@@ -985,13 +982,13 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
 
             await tokenSaleContract.sendTransaction({
                 value: 1 * ETH,
-                from: whitelistedInPresale
+                from: whitelistedInSafeMainSale
             });
 
             // try to get refund
             try {
-                await tokenSaleContract.refund(whitelistedInPresale, {
-                    from: whitelistedInPresale
+                await tokenSaleContract.refund(whitelistedInSafeMainSale, {
+                    from: whitelistedInSafeMainSale
                 });
                 assert.fail();
             } catch (error) {
@@ -1004,13 +1001,13 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
 
             await tokenSaleContract.sendTransaction({
                 value: 1 * ETH,
-                from: whitelistedInPresale
+                from: whitelistedInMainsale
             });
 
             // try to get refund
             try {
-                await tokenSaleContract.refund(whitelistedInPresale, {
-                    from: whitelistedInPresale
+                await tokenSaleContract.refund(whitelistedInMainsale, {
+                    from: whitelistedInMainsale
                 });
                 assert.fail();
             } catch (error) {
@@ -1143,7 +1140,7 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             }
         });
 
-        it('Should not allow presale contributor to claim their token before 140 days', async function () {
+        it('Should not allow presale contributor to claim their token before 90 days', async function () {
             var contributingEth = 30;
             await tokenSaleContract.setEthPrice(ETH_PRICE);
             await tokenSaleContract.sendTransaction({
@@ -1175,7 +1172,7 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             }
         });
 
-        it('Should allow presale contributor to claim their token after 140 days', async function () {
+        it('Should allow presale contributor to claim their token after 90 days', async function () {
             contributingEth = 50;
             await tokenSaleContract.setEthPrice(ETH_PRICE);
             var buyPrice = await tokenSaleContract.baseBuyPrice();
@@ -1202,11 +1199,12 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             await tokenSaleContract.activateToken();
             var timelock = TokenTimelockContract.at(tokenAddr);
 
-            // set the blocktime approximatively the 2019/01/01
+            // wait for 69 days because we already waited 21 weeks for the mainsale to finish
+            // and the presale vesting is 90 days
             web3.currentProvider.sendAsync({
                 jsonrpc: "2.0",
                 method: "evm_increaseTime",
-                params: [(3600 * 24 * 140) + 1],
+                params: [(3600 * 24 * 69) + 1],
                 id: 12345
             }, function (err, result) {});
 

--- a/test/GalionTokenSale.test.js
+++ b/test/GalionTokenSale.test.js
@@ -16,7 +16,10 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
     let timelock;
 
     var setContractToPausePhase = async function () {
-        await contract.setBuyPrice(BUYPRICE);
+        // during the presale, can only set the buyPrice once, so only set it if not set
+        if (await contract.baseBuyPrice() == 0) {
+            await contract.setBuyPrice(BUYPRICE);
+        }
         await contract.setPhase(1);
         await contract.addToWhitelist([whitelistedInPause]);
     }
@@ -208,7 +211,7 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             }
         });
     });
-    
+
     describe('Presale', async function () {
         it('should allow to add people to the whitelist', async function () {
             await contract.addToWhitelist([contributor]);
@@ -344,12 +347,12 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             await contract.setIndividualWeiCap(INDIVIDUAL_CAP * ETH);
             await contract.setPhase(2);
 
-            
+
             await contract.sendTransaction({
                 value: 10 * ETH,
                 from: whitelistedInPause
             });
-            
+
             assert.equal(web3.eth.getBalance(await contract.address), weiToContributeToReachPresaleHardCap + (10 * ETH));
             assert.equal(await token.balanceOf(whitelistedInPause), 10 * GLN * BUYPRICE);
         });
@@ -382,7 +385,7 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             assert.equal(await contract.getIndividualWeiCap(), 1 * ETH);
         });
     });
-    
+
     describe('Safe Mainsale', async function () {
         it('should not be able to start before individual cap is set', async function () {
             await setContractToPausePhase();
@@ -770,6 +773,7 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             } catch (error) {
                 assert(error.toString().includes('revert'), error.toString());
             }
+            
         });
 
         it('should not allow people to claim refund during the safe sale', async function () {

--- a/test/GalionTokenSale.test.js
+++ b/test/GalionTokenSale.test.js
@@ -840,14 +840,8 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             var lowBound = 0.1999 * await token.totalSupply();
 
             var tokenNumForCompany = (await token.balanceOf(COMPANY_ADDRESS)).toNumber()
-            if (tokenNumForCompany > highBound) {
-                console.log("company has " + tokenNumForCompany + " which is more than 10%");
-                assert.fail();
-            }
-            if (tokenNumForCompany < lowBound) {
-                console.log("company has " + tokenNumForCompany + " which is less than 10%");
-                assert.fail();
-            }
+            assert(tokenNumForCompany < highBound, 'company has ' + tokenNumForCompany + ' which is more than 20%');
+            assert(tokenNumForCompany > lowBound, 'company has ' + tokenNumForCompany + ' which is less than 20%');
         });
 
         it('should send 10% of supply to advisory wallet', async function () {
@@ -860,15 +854,9 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             var highBound = 0.1001 * await token.totalSupply();
             var lowBound = 0.0999 * await token.totalSupply();
 
-            var tokenNumForAdvisory = (await token.balanceOf(ADVISORY_ADDRESS)).toNumber()
-            if (tokenNumForAdvisory > highBound) {
-                console.log("advisory has " + tokenNumForAdvisory + " which is more than 10%");
-                assert.fail();
-            }
-            if (tokenNumForAdvisory < lowBound) {
-                console.log("advisory has " + tokenNumForAdvisory + " which is less than 10%");
-                assert.fail();
-            }
+            var tokenNumForAdvisory = (await token.balanceOf(ADVISORY_ADDRESS)).toNumber();
+            assert(tokenNumForAdvisory < highBound, 'advisory has ' + tokenNumForAdvisory + ' which is more than 10%');
+            assert(tokenNumForAdvisory > lowBound, 'advisory has ' + tokenNumForAdvisory + ' which is less than 10%');
         });
 
         it('should vest 2% of max supply for each 5 team member & create timelocks', async function () {
@@ -882,54 +870,24 @@ contract('GalionToken', function ([owner, whitelistedInPresale, whitelistedInPau
             var lowBound = 0.01999 * await token.totalSupply();
 
             var tokenNumFounder1 = (await token.balanceOf(await tokenSaleContract.teamLockAddress1())).toNumber();
-            if (tokenNumFounder1 > highBound) {
-                console.log("founder1 has " + tokenNumFounder1 + " which is more than 2%");
-                assert.fail();
-            }
-            if (tokenNumFounder1 < lowBound) {
-                console.log("founder1 has " + tokenNumFounder1 + " which is less than 2%");
-                assert.fail();
-            }
+            assert(tokenNumFounder1 < highBound, 'founder 1 has ' + tokenNumFounder1 + ' which is more than 2%');
+            assert(tokenNumFounder1 > lowBound, 'founder 1 has ' + tokenNumFounder1 + ' which is less than 2%');
 
             var tokenNumFounder2 = (await token.balanceOf(await tokenSaleContract.teamLockAddress2())).toNumber();
-            if (tokenNumFounder2 > highBound) {
-                console.log("founder2 has " + tokenNumFounder2 + " which is more than 2%");
-                assert.fail();
-            }
-            if (tokenNumFounder2 < lowBound) {
-                console.log("founder2 has " + tokenNumFounder2 + " which is less than 2%");
-                assert.fail();
-            }
+            assert(tokenNumFounder2 < highBound, 'founder 2 has ' + tokenNumFounder2 + ' which is more than 2%');
+            assert(tokenNumFounder2 > lowBound, 'founder 2 has ' + tokenNumFounder2 + ' which is less than 2%');
 
             var tokenNumFounder3 = (await token.balanceOf(await tokenSaleContract.teamLockAddress3())).toNumber();
-            if (tokenNumFounder3 > highBound) {
-                console.log("Founder3 has " + tokenNumFounder3 + " which is more than 2%");
-                assert.fail();
-            }
-            if (tokenNumFounder3 < lowBound) {
-                console.log("Founder3 has " + tokenNumFounder3 + " which is less than 2%");
-                assert.fail();
-            }
+            assert(tokenNumFounder3 < highBound, 'founder 3 has ' + tokenNumFounder3 + ' which is more than 2%');
+            assert(tokenNumFounder3 > lowBound, 'founder 3 has ' + tokenNumFounder3 + ' which is less than 2%');
 
             var tokenNumFounder4 = (await token.balanceOf(await tokenSaleContract.teamLockAddress4())).toNumber();
-            if (tokenNumFounder4 > highBound) {
-                console.log("Founder4 has " + tokenNumFounder4 + " which is more than 2%");
-                assert.fail();
-            }
-            if (tokenNumFounder4 < lowBound) {
-                console.log("Founder4 has " + tokenNumFounder4 + " which is less than 2%");
-                assert.fail();
-            }
+            assert(tokenNumFounder4 < highBound, 'founder 4 has ' + tokenNumFounder4 + ' which is more than 2%');
+            assert(tokenNumFounder4 > lowBound, 'founder 4 has ' + tokenNumFounder4 + ' which is less than 2%');
 
             var tokenNumFounder5 = (await token.balanceOf(await tokenSaleContract.teamLockAddress5())).toNumber();
-            if (tokenNumFounder5 > highBound) {
-                console.log("Founder5 has " + tokenNumFounder5 + " which is more than 2%");
-                assert.fail();
-            }
-            if (tokenNumFounder5 < lowBound) {
-                console.log("Founder5 has " + tokenNumFounder5 + " which is less than 2%");
-                assert.fail();
-            }
+            assert(tokenNumFounder5 < highBound, 'founder 5 has ' + tokenNumFounder5 + ' which is more than 2%');
+            assert(tokenNumFounder5 > lowBound, 'founder 5 has ' + tokenNumFounder5 + ' which is less than 2%');
         });
     });
 

--- a/truffle.js
+++ b/truffle.js
@@ -10,7 +10,7 @@ module.exports = {
   },
   networks: {
     development: {
-      host: 'localhost',
+      host: '127.0.0.1',
       port: 8545,
       network_id: '*',
       gas: 4 * 1e6,


### PR DESCRIPTION
- presale bonus is now 30% and fixed (cannot change it after deploy)
- presale contributor will have their bonus token in a token time lock contract for 3 months (10 weeks)
- the total supply is now variable as it will depend on the amount contributed (and the percentage during presale/mainsale)
- company and founder tokens are now calculated in % of the real total supply (before that if the token sale was not fully contributed the company / founder would have a lot more than 40% of total tokens)
- the soft cap is now calculated in wei
- the price set is now in dollar an allow to calculate exactly the differents caps in order to raise 9.5M$
- the main sale duration is now 3 weeks
